### PR TITLE
Lots of dashboard fixups

### DIFF
--- a/dashboard/_includes/common_sensors.html
+++ b/dashboard/_includes/common_sensors.html
@@ -190,7 +190,7 @@
             const build_time = new Date("{{ site.time }}");
             const d = new Date(Date.UTC(p[0], p[1] - 1, p[2], p[3], p[4], p[5]));
             const ageSeconds = (build_time - d) / 1000;
-            const sixHoursInSeconds = 2 * 3600;
+            const sixHoursInSeconds = 6 * 3600;
             el.textContent = d.toLocaleDateString() + "  " + d.toLocaleTimeString();
             if (el.dataset.row === "1" && ageSeconds > sixHoursInSeconds) {
                 el.parentElement.classList.add("table-warning");


### PR DESCRIPTION
- Fixes #56 where plot max value is now the site build time
- Fixes #38 to disable scroll wheel to make it easier to view on a computer
- Fixes #35 to add page rendered time in a footer
- Fixes #34 to color the top (most recent) entry in the timestamps if the result is stale (aged > 6 hours at build time)