### PR TITLE
Remove build_name input from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      build_name:
-        description: "Custom build name (e.g., dev-test, staging)"
-        required: true
-        default: "manual-build"
 
 jobs:
   build:


### PR DESCRIPTION
Removed custom build name input from workflow dispatch. It's not needed for anything.